### PR TITLE
Add v3 endpoint to pdf-service which handles utf-8 properly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-    image: hmcts.azurecr.io/hmcts/cmc-pdf-service
+    image: hmctspublic.azurecr.io/cmc/pdf-service
     environment:
       # used by java-logging library
       - ROOT_APPENDER
@@ -18,6 +18,6 @@ services:
       - REFORM_SERVICE_NAME
       - REFORM_TEAM
       - REFORM_ENVIRONMENT
-      - AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY
+      - AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY=0000-0000-0000-0000
     ports:
       - 5500:5500

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pdf/service/GeneratedPDFContentV2Test.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pdf/service/GeneratedPDFContentV2Test.java
@@ -47,6 +47,26 @@ public class GeneratedPDFContentV2Test {
     }
 
     @Test
+    public void shouldCreateExpectedPdfWithUtf8CharactersEncoded() throws Exception {
+        Response response = makeRequest(
+            "<html><body>&#163;200</body></html>",
+            Collections.emptyMap()
+        );
+
+        assertThat(textContentOf(response.getBody().asByteArray())).contains("£200");
+    }
+
+    @Test
+    public void shouldCreateExpectedPdfWithUtf8Characters() throws Exception {
+        Response response = makeRequest(
+            "<html><body>£200</body></html>",
+            Collections.emptyMap()
+        );
+
+        assertThat(textContentOf(response.getBody().asByteArray())).contains("£200");
+    }
+
+    @Test
     public void shouldCreateExpectedPdfFromPlainTwigTemplateAndPlaceholders() throws Exception {
         Response response = makeRequest(
             "<html>{{ hello }}</html>",

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pdf/service/GeneratedPDFContentV3Test.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pdf/service/GeneratedPDFContentV3Test.java
@@ -14,7 +14,7 @@ import org.pdfbox.pdmodel.PDDocument;
 import org.pdfbox.util.PDFTextStripper;
 import org.springframework.http.MediaType;
 import uk.gov.hmcts.reform.pdf.service.domain.GeneratePdfRequest;
-import uk.gov.hmcts.reform.pdf.service.endpoint.v2.PDFGenerationEndpointV2;
+import uk.gov.hmcts.reform.pdf.service.endpoint.v3.PDFGenerationEndpointV3;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GeneratedPDFContentV2Test {
+public class GeneratedPDFContentV3Test {
 
     private static final String API_URL = "/pdfs";
     private static ObjectMapper objectMapper = new ObjectMapper();
@@ -46,10 +46,21 @@ public class GeneratedPDFContentV2Test {
         assertThat(textContentOf(response.getBody().asByteArray())).contains("Hello!");
     }
 
+
     @Test
     public void shouldCreateExpectedPdfWithUtf8CharactersEncoded() throws Exception {
         Response response = makeRequest(
             "<html><body>&#163;200</body></html>",
+            Collections.emptyMap()
+        );
+
+        assertThat(textContentOf(response.getBody().asByteArray())).contains("£200");
+    }
+
+    @Test
+    public void shouldCreateExpectedPdfWithUtf8Characters() throws Exception {
+        Response response = makeRequest(
+            "<html><body>£200</body></html>",
             Collections.emptyMap()
         );
 
@@ -84,7 +95,7 @@ public class GeneratedPDFContentV2Test {
         return RestAssured
             .given()
             .accept(MediaType.APPLICATION_PDF_VALUE)
-            .contentType(PDFGenerationEndpointV2.MEDIA_TYPE)
+            .contentType(PDFGenerationEndpointV3.MEDIA_TYPE)
             .body(json)
             .when()
             .post(API_URL);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pdf/service/integration/GeneratedPDFContentV3Test.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pdf/service/integration/GeneratedPDFContentV3Test.java
@@ -1,0 +1,101 @@
+package uk.gov.hmcts.reform.pdf.service.integration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.applicationinsights.TelemetryClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pdfbox.pdmodel.PDDocument;
+import org.pdfbox.util.PDFTextStripper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import uk.gov.hmcts.reform.pdf.generator.HTMLToPDFConverter;
+import uk.gov.hmcts.reform.pdf.service.domain.GeneratePdfRequest;
+import uk.gov.hmcts.reform.pdf.service.endpoint.v3.PDFGenerationEndpointV3;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class GeneratedPDFContentV3Test {
+
+    private static final String API_URL = "/pdfs";
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockBean
+    protected TelemetryClient telemetry;
+
+    @Autowired
+    protected MockMvc webClient;
+
+    @SpyBean
+    private HTMLToPDFConverter converter;
+
+    private static String textContentOf(byte[] pdfData) throws IOException {
+        PDDocument pdfDocument = PDDocument.load(new ByteArrayInputStream(pdfData));
+        try {
+            return new PDFTextStripper().getText(pdfDocument);
+        } finally {
+            pdfDocument.close();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldCreateExpectedPdfFromPlainHtmlTemplate() throws Exception {
+        MockHttpServletResponse response = getResponse(getRequest(
+            "<html><body>Hello!</body></html>",
+            Collections.emptyMap()
+        ));
+
+        assertThat(textContentOf(response.getContentAsByteArray())).contains("Hello!");
+        verify(converter, times(1)).convert(any(), anyMap());
+    }
+
+    @Test
+    public void shouldCreateExpectedPdfFromPlainTwigTemplateAndPlaceholders() throws Exception {
+        MockHttpServletResponse response = getResponse(getRequest(
+            "<html>{{ hello }}</html>",
+            ImmutableMap.of("hello", "World!")
+        ));
+
+        assertThat(textContentOf(response.getContentAsByteArray())).contains("World!");
+        verify(converter, times(1)).convert(any(), anyMap());
+    }
+
+    private MockHttpServletRequestBuilder getRequest(String template, Map<String, Object> values)
+        throws JsonProcessingException {
+
+        GeneratePdfRequest request = new GeneratePdfRequest(template, values);
+        String json = objectMapper.writeValueAsString(request);
+
+        return post(API_URL)
+            .accept(MediaType.APPLICATION_PDF_VALUE)
+            .contentType(PDFGenerationEndpointV3.MEDIA_TYPE)
+            .content(json);
+    }
+
+    private MockHttpServletResponse getResponse(MockHttpServletRequestBuilder requestBuilder) throws Exception {
+        return webClient.perform(requestBuilder).andReturn().getResponse();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2.java
+++ b/src/main/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2.java
@@ -44,7 +44,8 @@ public class PDFGenerationEndpointV2 {
         name = "/pdfs",
         docLink = "https://github.com/hmcts/cmc-pdf-service#standard-api",
         expiryDate = "2019-01-04",
-        note = "Please use `/pdfs` with the mediatype application/vnd.uk.gov.hmcts.pdf-service.v3+json;charset=UTF-8  instead.")
+        note = "Please use `/pdfs` with the "
+            + "mediatype application/vnd.uk.gov.hmcts.pdf-service.v3+json;charset=UTF-8 instead.")
     public ResponseEntity<ByteArrayResource> generateFromHtml(
         @RequestBody GeneratePdfRequest request
     ) {

--- a/src/main/java/uk/gov/hmcts/reform/pdf/service/endpoint/v3/PDFGenerationEndpointV3.java
+++ b/src/main/java/uk/gov/hmcts/reform/pdf/service/endpoint/v3/PDFGenerationEndpointV3.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.pdf.service.endpoint.v2;
+package uk.gov.hmcts.reform.pdf.service.endpoint.v3;
 
 import io.swagger.annotations.Api;
 import org.slf4j.Logger;
@@ -11,46 +11,42 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.hmcts.reform.api.deprecated.APIDeprecated;
 import uk.gov.hmcts.reform.pdf.generator.HTMLToPDFConverter;
 import uk.gov.hmcts.reform.pdf.service.appinsights.AppInsightsEventTracker;
 import uk.gov.hmcts.reform.pdf.service.domain.GeneratePdfRequest;
+
+import java.nio.charset.StandardCharsets;
 
 @Api
 @RestController
 @RequestMapping(
     path = "pdfs",
-    consumes = PDFGenerationEndpointV2.MEDIA_TYPE,
+    consumes = PDFGenerationEndpointV3.MEDIA_TYPE,
     produces = MediaType.APPLICATION_PDF_VALUE
 )
-public class PDFGenerationEndpointV2 {
+public class PDFGenerationEndpointV3 {
 
-    public static final String MEDIA_TYPE = "application/vnd.uk.gov.hmcts.pdf-service.v2+json;charset=UTF-8";
+    public static final String MEDIA_TYPE = "application/vnd.uk.gov.hmcts.pdf-service.v3+json;charset=UTF-8";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PDFGenerationEndpointV2.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PDFGenerationEndpointV3.class);
 
     private final HTMLToPDFConverter htmlToPdf;
 
     private final AppInsightsEventTracker eventTracker;
 
     @Autowired
-    public PDFGenerationEndpointV2(HTMLToPDFConverter htmlToPdf, AppInsightsEventTracker eventTracker) {
+    public PDFGenerationEndpointV3(HTMLToPDFConverter htmlToPdf, AppInsightsEventTracker eventTracker) {
         this.htmlToPdf = htmlToPdf;
         this.eventTracker = eventTracker;
     }
 
     @PostMapping
-    @APIDeprecated(
-        name = "/pdfs",
-        docLink = "https://github.com/hmcts/cmc-pdf-service#standard-api",
-        expiryDate = "2019-01-04",
-        note = "Please use `/pdfs` with the mediatype application/vnd.uk.gov.hmcts.pdf-service.v3+json;charset=UTF-8  instead.")
     public ResponseEntity<ByteArrayResource> generateFromHtml(
         @RequestBody GeneratePdfRequest request
     ) {
         // PMD doesn't like the public field
         byte[] pdfDocument = htmlToPdf.convert(
-            request.template.getBytes(), request.values); //NOPMD
+            request.template.getBytes(StandardCharsets.UTF_8), request.values); //NOPMD
 
         LOGGER.info("Generated document");
         eventTracker.trackFileSize(pdfDocument.length);


### PR DESCRIPTION
Currently some teams are relying on the platform default encoding instead of UTF-8 when sending requests, the API requires utf-8 but we had a bug and weren't explicitly getting bytes with the right Content-Type.

This is one way of fixing it without breaking consumers...