### PR TITLE
Downgrade pact version to fix the pipeline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ tasks.withType(JavaExec).configureEach {
 
 ext {
     log4JVersion = '2.20.0'
-    pactVersion = '4.6.3'
+    pactVersion = '4.3.15'
 }
 
 dependencies {


### PR DESCRIPTION
Its broken somewhere in https://github.com/pact-foundation/pact-jvm/commit/72f9193ba58ff9020b4523f225ce94d063f062ce which is 4.3.16. But cannot make it to work without changing all clients. Tried to upgarde clients to use latest version, but looks like there are a lot of other changes needed. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
