### PR TITLE
DTSPO-14929 - Migrating App Insights from Classic to Workspace-based.

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -105,5 +105,26 @@
    ]]></notes>
     <cve>CVE-2023-35116</cve>
   </suppress>
+  <suppress until="2024-01-12">
+   <notes><![CDATA[
+   file name: jackson-databind-2.15.3.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+   <cve>CVE-2023-35116</cve>
+</suppress>
+<suppress until="2024-01-12">
+   <notes><![CDATA[
+   file name: logback-classic-1.4.11.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
+   <cve>CVE-2023-6378</cve>
+</suppress>
+<suppress until="2024-01-12">
+   <notes><![CDATA[
+   file name: logback-core-1.4.11.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
+   <cve>CVE-2023-6378</cve>
+</suppress>
 
 </suppressions>

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -19,6 +19,9 @@ module "application_insights" {
   resource_group_name = azurerm_resource_group.rg.name
 
   common_tags = var.common_tags
+
+  daily_data_cap_in_gb = var.daily_data_cap_in_gb
+  
 }
 
 moved {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -9,26 +9,28 @@ resource "azurerm_resource_group" "rg" {
   tags = var.common_tags
 }
 
-resource "azurerm_application_insights" "appinsights" {
-  name                = "${var.product}-${var.component}-appinsights-${var.env}"
-  location            = var.location
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env     = var.env
+  product = var.product
+  name    = "${var.product}-${var.component}-appinsights"
+
   resource_group_name = azurerm_resource_group.rg.name
-  application_type    = "web"
 
-  tags = var.common_tags
-
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance
-      application_type,
-    ]
-  }
+  common_tags = var.common_tags
 }
+
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
+}
+
+
 
 resource "azurerm_key_vault_secret" "AZURE_APPINSGHTS_KEY" {
   name         = "app-insights-connection-string"
-  value        = azurerm_application_insights.appinsights.connection_string
+  value        = module.application_insights.connection_string
   key_vault_id = data.azurerm_key_vault.rpe_shared_vault.id
 }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -16,3 +16,8 @@ variable "subscription" {}
 variable "common_tags" {
   type = map(string)
 }
+
+variable "daily_data_cap_in_gb" {
+  description = "Specifies the Application Insights component daily data volume cap in GB"
+  default     = 100
+}


### PR DESCRIPTION
Jira link (if applicable)
DTSPO-14929

Change description
Moving App Insights to module
Upgrading App Insights from Classic to workspace-based using [app-insights-migration-tool](https://github.com/hmcts/app-insights-migration-tool)