### PR TITLE
Suooress dependancies which cannot be upgraded

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -105,21 +105,21 @@
    ]]></notes>
     <cve>CVE-2023-35116</cve>
   </suppress>
-  <suppress until="2024-01-12">
+  <suppress until="2024-06-30">
    <notes><![CDATA[
    file name: jackson-databind-2.15.3.jar
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
    <cve>CVE-2023-35116</cve>
 </suppress>
-<suppress until="2024-01-12">
+<suppress until="2024-06-30">
    <notes><![CDATA[
    file name: logback-classic-1.4.11.jar
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
    <cve>CVE-2023-6378</cve>
 </suppress>
-<suppress until="2024-01-12">
+<suppress until="2024-06-30">
    <notes><![CDATA[
    file name: logback-core-1.4.11.jar
    ]]></notes>


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines


### Change description ###

Suppressed dependancy which cannot be upgraded because it has been used by the latest version of the dependancy - e.g. 
`implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
