### PR TITLE
Add null check for context when there no pacts found

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2ProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2ProviderTest.java
@@ -48,7 +48,9 @@ public class PDFGenerationEndpointV2ProviderTest {
         MockMvcTestTarget testTarget = new MockMvcTestTarget();
         pdfGenerationEndpointV2 = new PDFGenerationEndpointV2(new HTMLToPDFConverter(), appInsightsEventTrackerMock);
         testTarget.setControllers(pdfGenerationEndpointV2);
-        context.setTarget(testTarget);
+        if (context != null){
+            context.setTarget(testTarget);
+        }
     }
 
     @State({"A request to generate a divorce pdf document"})

--- a/src/contractTest/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2ProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2ProviderTest.java
@@ -38,7 +38,7 @@ public class PDFGenerationEndpointV2ProviderTest {
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
     void pactVerificationTestTemplate(PactVerificationContext context) {
-        if (context != null){
+        if (context != null) {
             context.verifyInteraction();
         }
     }
@@ -50,7 +50,7 @@ public class PDFGenerationEndpointV2ProviderTest {
         MockMvcTestTarget testTarget = new MockMvcTestTarget();
         pdfGenerationEndpointV2 = new PDFGenerationEndpointV2(new HTMLToPDFConverter(), appInsightsEventTrackerMock);
         testTarget.setControllers(pdfGenerationEndpointV2);
-        if (context != null){
+        if (context != null) {
             context.setTarget(testTarget);
         }
     }

--- a/src/contractTest/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2ProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2ProviderTest.java
@@ -38,7 +38,9 @@ public class PDFGenerationEndpointV2ProviderTest {
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
     void pactVerificationTestTemplate(PactVerificationContext context) {
-        context.verifyInteraction();
+        if (context != null){
+            context.verifyInteraction();
+        }
     }
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-17366


### Change description ###
- Adds a null check for context before it is used
- Mentioned in this issue https://github.com/pact-foundation/pact-jvm/issues/768#issuecomment-601965237 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
