### PR TITLE
feat: DTSPO-31436 Upgrade PDF service to Java 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG APP_INSIGHTS_AGENT_VERSION=3.4.19
 ARG PLATFORM=""
-FROM hmctspublic.azurecr.io/base/java${PLATFORM}:21-distroless
+FROM hmctspublic.azurecr.io/base/java${PLATFORM}:25-distroless
 
 # Mandatory!
 ENV APP pdf-service-all.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG APP_INSIGHTS_AGENT_VERSION=3.4.19
 ARG PLATFORM=""
-FROM hmctspublic.azurecr.io/base/java${PLATFORM}:25-distroless
+FROM hmctsprod.azurecr.io/base/java${PLATFORM}:25-distroless
 
 # Mandatory!
 ENV APP pdf-service-all.jar

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The template, besides containing ordinary HTML markup, can also contain inline C
 
 ### Prerequisites
 
-- [Java 21](https://www.oracle.com/java)
+- [Java 25](https://www.oracle.com/java)
 - [Docker](https://www.docker.com)
 
 ![diagram](docs/component-diagram.jpg)

--- a/acb.tpl.yaml
+++ b/acb.tpl.yaml
@@ -1,7 +1,7 @@
 version: 1.0-preview-1
 steps:
   - id: pull-base-image-amd64
-    cmd: docker pull --platform linux/amd64 hmctspublic.azurecr.io/base/java:25-distroless && docker tag hmctspublic.azurecr.io/base/java:25-distroless hmctspublic.azurecr.io/base/java/linux/amd64:25-distroless
+    cmd: docker pull --platform linux/amd64 hmctsprod.azurecr.io/base/java:25-distroless && docker tag hmctsprod.azurecr.io/base/java:25-distroless hmctsprod.azurecr.io/base/java/linux/amd64:25-distroless
     when: ["-"]
     keep: true
 
@@ -16,7 +16,7 @@ steps:
     keep: true
 
   - id: pull-base-image-arm64
-    cmd: docker pull --platform linux/arm64 hmctspublic.azurecr.io/base/java:25-distroless && docker tag hmctspublic.azurecr.io/base/java:25-distroless hmctspublic.azurecr.io/base/java/linux/arm64:25-distroless
+    cmd: docker pull --platform linux/arm64 hmctsprod.azurecr.io/base/java:25-distroless && docker tag hmctsprod.azurecr.io/base/java:25-distroless hmctsprod.azurecr.io/base/java/linux/arm64:25-distroless
     when:
       - pull-base-image-amd64
     keep: true

--- a/acb.tpl.yaml
+++ b/acb.tpl.yaml
@@ -1,7 +1,7 @@
 version: 1.0-preview-1
 steps:
   - id: pull-base-image-amd64
-    cmd: docker pull --platform linux/amd64 hmctspublic.azurecr.io/base/java:21-distroless && docker tag hmctspublic.azurecr.io/base/java:21-distroless hmctspublic.azurecr.io/base/java/linux/amd64:21-distroless
+    cmd: docker pull --platform linux/amd64 hmctspublic.azurecr.io/base/java:25-distroless && docker tag hmctspublic.azurecr.io/base/java:25-distroless hmctspublic.azurecr.io/base/java/linux/amd64:25-distroless
     when: ["-"]
     keep: true
 
@@ -16,7 +16,7 @@ steps:
     keep: true
 
   - id: pull-base-image-arm64
-    cmd: docker pull --platform linux/arm64 hmctspublic.azurecr.io/base/java:21-distroless && docker tag hmctspublic.azurecr.io/base/java:21-distroless hmctspublic.azurecr.io/base/java/linux/arm64:21-distroless
+    cmd: docker pull --platform linux/arm64 hmctspublic.azurecr.io/base/java:25-distroless && docker tag hmctspublic.azurecr.io/base/java:25-distroless hmctspublic.azurecr.io/base/java/linux/arm64:25-distroless
     when:
       - pull-base-image-amd64
     keep: true

--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ allprojects {
 
   ext {
     junit = '5.12.2'
-    reformLogging = '6.1.9'
+    reformLogging = '8.0.0'
     flyingSaucer = flyingSaucerVersion
     openPdf = dependencyManagement.importedProperties['openpdf.version']
   }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'org.springframework.boot' version '3.3.5'
+  id 'org.springframework.boot' version '3.5.5'
   id 'org.owasp.dependencycheck' version '12.2.0'
   id 'com.github.ben-manes.versions' version '0.53.0'
   id 'se.patrikerdes.use-latest-versions' version '0.2.19'
@@ -19,7 +19,7 @@ version = '1.0.2'
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(21)
+    languageVersion = JavaLanguageVersion.of(25)
   }
 }
 
@@ -30,7 +30,6 @@ testing {
     }
 
     integrationTest(JvmTestSuite) {
-      testType = TestSuiteType.INTEGRATION_TEST
       dependencies {
         implementation project()
         implementation sourceSets.test.runtimeClasspath
@@ -46,7 +45,6 @@ testing {
     }
 
     functionalTest(JvmTestSuite) {
-      testType = TestSuiteType.FUNCTIONAL_TEST
       dependencies {
         implementation project()
         implementation sourceSets.test.runtimeClasspath
@@ -183,7 +181,7 @@ allprojects {
   }
 
   ext {
-    junit = '5.10.3'
+    junit = '5.12.2'
     reformLogging = '6.1.9'
     flyingSaucer = flyingSaucerVersion
     openPdf = dependencyManagement.importedProperties['openpdf.version']
@@ -225,7 +223,7 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
   implementation group: 'com.google.guava', name: 'guava', version: '33.5.0-jre'
 
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.8.0'
+  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.6'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLogging
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-web', version: '3.7.8'
@@ -248,15 +246,17 @@ dependencies {
   contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5', version: pactVersion
   contractTestImplementation group: 'au.com.dius.pact.provider', name: 'spring', version: pactVersion
   contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5spring', version: pactVersion
-  contractTestImplementation("org.junit.jupiter:junit-jupiter-api:5.13.2")
-  contractTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.13.2")
-  contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.13.2')
+  contractTestImplementation("org.junit.jupiter:junit-jupiter-api:${junit}")
+  contractTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junit}")
+  contractTestImplementation("org.junit.jupiter:junit-jupiter-api:${junit}")
 
   implementation project(':pdf-generator')
 }
 
 
-mainClassName = 'uk.gov.hmcts.reform.pdf.service.PDFServiceApplication'
+application {
+  mainClass = 'uk.gov.hmcts.reform.pdf.service.PDFServiceApplication'
+}
 
 bootJar {
   archiveFileName = 'pdf-service-all.jar'

--- a/charts/rpe-pdf-service/Chart.yaml
+++ b/charts/rpe-pdf-service/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 dependencies:
   - name: java
     version: 5.3.0
-    repository: 'oci://hmctspublic.azurecr.io/helm'
+    repository: 'oci://hmctsprod.azurecr.io/helm'

--- a/charts/rpe-pdf-service/Chart.yaml
+++ b/charts/rpe-pdf-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rpe-pdf-service
 home: https://github.com/hmcts/rpe-pdf-service
-version: 0.6.28
+version: 0.6.29
 description: PDF generation service
 maintainers:
   - name: HMCTS Platform engineering team

--- a/charts/rpe-pdf-service/values.yaml
+++ b/charts/rpe-pdf-service/values.yaml
@@ -5,7 +5,7 @@ java:
   environment:
     LOGBACK_REQUIRE_ALERT_LEVEL: 'false'
     LOGBACK_REQUIRE_ERROR_CODE: 'false'
-  image: 'hmctspublic.azurecr.io/rpe/pdf-service:latest'
+  image: 'hmctsprod.azurecr.io/rpe/pdf-service:latest'
   keyVaults:
     "rpe-shared":
       secrets:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/contractTest/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2ProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2ProviderTest.java
@@ -14,7 +14,7 @@ import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.pdf.generator.HTMLToPDFConverter;
 import uk.gov.hmcts.reform.pdf.service.appinsights.AppInsightsEventTracker;
@@ -31,7 +31,7 @@ public class PDFGenerationEndpointV2ProviderTest {
 
     PDFGenerationEndpointV2 pdfGenerationEndpointV2;
 
-    @MockBean
+    @MockitoBean
     AppInsightsEventTracker appInsightsEventTrackerMock;
 
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pdf/service/integration/GeneratedPDFContentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pdf/service/integration/GeneratedPDFContentTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -26,7 +26,7 @@ public class GeneratedPDFContentTest {
 
     private static final String API_URL = "/api/v1/pdf-generator/html";
 
-    @MockBean
+    @MockitoBean
     protected TelemetryClient telemetry;
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pdf/service/integration/GeneratedPDFContentV2Test.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pdf/service/integration/GeneratedPDFContentV2Test.java
@@ -11,10 +11,10 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -42,13 +42,13 @@ public class GeneratedPDFContentV2Test {
     private static final String API_URL = "/pdfs";
     private static ObjectMapper objectMapper = new ObjectMapper();
 
-    @MockBean
+    @MockitoBean
     protected TelemetryClient telemetry;
 
     @Autowired
     protected MockMvc webClient;
 
-    @SpyBean
+    @MockitoSpyBean
     private HTMLToPDFConverter converter;
 
     private static String textContentOf(byte[] pdfData) throws IOException {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pdf/service/integration/ResponseCodesTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pdf/service/integration/ResponseCodesTest.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -26,7 +26,7 @@ public class ResponseCodesTest {
     private static final String NO_VALUES = "{ }";
     private static final String TEMPLATE = "template";
 
-    @MockBean
+    @MockitoBean
     protected TelemetryClient telemetry;
 
     @Autowired

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/appinsights/AppInsightsEventTrackerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/appinsights/AppInsightsEventTrackerTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.pdf.service.domain.matchers.EventMetricsMatcher;
 import uk.gov.hmcts.reform.pdf.service.domain.matchers.KbEventPropertiesMatcher;
@@ -18,10 +18,10 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 @AutoConfigureMockMvc
 public class AppInsightsEventTrackerTest {
-    @MockBean
+    @MockitoBean
     private TelemetryClient telemetryClient;
 
-    @MockBean
+    @MockitoBean
     private FileSizeConverter fileSizeConverter;
 
     private static final String EXPECTED_EVENT_NAME = "PDF File size";

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/endpoint/GetWelcomeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/endpoint/GetWelcomeTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.pdf.generator.HTMLToPDFConverter;
@@ -22,10 +22,10 @@ public class GetWelcomeTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     protected HTMLToPDFConverter converter; // NOPMD we only need context to load
 
-    @MockBean
+    @MockitoBean
     protected AppInsightsEventTracker eventTracker;
 
     @Test


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-31436


### Change description ###

- Java toolchain and runtime base image upgraded from 21 to 25
- Gradle wrapper upgraded to 9.1.0
- Spring Boot upgraded to 3.5.5
- Springdoc upgraded to 2.8.6
- JUnit dependencies aligned to 5.12.2
 - Deprecated @MockBean and @SpyBean usages replaced with @MockitoBean and @MockitoSpyBean.
 
### Testing ###

- Built the Docker image using the Java 25 distroless base image:
docker build -t rpe-pdf-service:dtspo-31436 .

- Started the container locally and verified:
    - Application started using Java 25.0.1 and Spring Boot 3.5.5.
    - GET /health returned UP.
    - GET / returned Welcome to Pdf Service.
    - GET /v3/api-docs returned a valid OpenAPI 3.1.0 document.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
